### PR TITLE
Update Google Fonts implementation

### DIFF
--- a/app/GameserverApp/Helpers/SiteHelper.php
+++ b/app/GameserverApp/Helpers/SiteHelper.php
@@ -98,7 +98,7 @@ class SiteHelper extends Helper
 
     public static function googleFontsUrl()
     {
-        return 'https://fonts.googleapis.com/css2?family=' . urlencode(self::googleFont()) . ':wght@100;300;500;700&display=swap';
+        return 'https://fonts.googleapis.com/css2?family=' . urlencode(self::googleFont()) . '&display=swap';
     }
 
     public static function googleAnalyticsId()

--- a/resources/views/layouts/v3/_meta.blade.php
+++ b/resources/views/layouts/v3/_meta.blade.php
@@ -27,6 +27,8 @@
 
 <title>{{$page['title'] or 'Community website'}} - {{GameserverApp\Helpers\SiteHelper::name()}}</title>
 
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href='{{GameserverApp\Helpers\SiteHelper::googleFontsUrl()}}' rel='stylesheet' type='text/css'>
 
 <link rel="stylesheet" type="text/css" href="{{ mix('css/style.css') }}">


### PR DESCRIPTION
This pull request covers 2 issues:

1. **Single-weight font-families throw 400 error when weight subclasses are included in the request.**
Since there is no way to determine the available weights, I have removed them from the request entirely. See additional notes below.
Example:
```https://fonts.googleapis.com/css2?family=Twinkle+Star:wght@100;300;500;700&display=swap``` (not loading)
```https://fonts.googleapis.com/css2?family=Twinkle+Star&display=swap``` (loading)

2. **Added link tags to preconnect to Google API**
(see: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preconnect)

> Additional notes: Pages seem to load faster, even when a complete font-family is loaded (I tested with Ubuntu, which contains 8 styles). I assume this is because the page only loads the required weight/subset. When multiple weights are used on a page, the size of the font file is larger, but it only uses 1 request as opposed to multiple requests per weight.